### PR TITLE
Fix messages view

### DIFF
--- a/client/src/components/Dashboard/Messages/Messages.js
+++ b/client/src/components/Dashboard/Messages/Messages.js
@@ -86,7 +86,7 @@ class AllMessages extends Component {
       <div className="messages-wrapper">
         <MessageContext.Provider value={{ activeMessage, messages, toggle: this.changeActiveMessage }}>
           <MessagesOverview  />
-          {messages.length ? <MessageReply onSubmit={this.onSubmit} /> : ''}
+          {messages.length && <MessageReply onSubmit={this.onSubmit} />}
         </MessageContext.Provider>
       </div> 
     );


### PR DESCRIPTION
This PR fixes the messages view not showing anything at all when the user does not have any messages. It does not change any existing styles nor does it add any.

- With messages:
<img width="1552" alt="codebuddy-chrome" src="https://user-images.githubusercontent.com/16165462/44864905-13569480-ac81-11e8-9351-1f39f66a3622.png">

- Without messages:
<img width="1552" alt="codebuddy-chrome-no-messages" src="https://user-images.githubusercontent.com/16165462/44864906-13ef2b00-ac81-11e8-955b-8026accb45c2.png">
