### PR TITLE
Add space in title before glowing text

### DIFF
--- a/client/src/components/LandingPage/App/title.tsx
+++ b/client/src/components/LandingPage/App/title.tsx
@@ -24,7 +24,7 @@ export default class Title extends Component<{}, State> {
     const index: number = activeIndex % WORDS.length;
     return (
       <h1 id="title">
-        Find A Partner To
+        Find A Partner To&nbsp;
         <span id="word">{WORDS[index].word}</span>
       </h1>
     );


### PR DESCRIPTION
Add space after 'Find a Partner To' and the glowing word in the app title on homepage.